### PR TITLE
refactor: move user creation and listing to service

### DIFF
--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -1,10 +1,13 @@
-const users = [];
+const { createUser, listUsers } = require('../services/usersService');
 
-function createUser(req, res) {
-  const { name, email, phone, password } = req.body;
-  const user = { name, email, phone, password };
-  users.push(user);
+function createUserController(req, res) {
+  const user = createUser(req.body);
   res.status(201).json(user);
 }
 
-module.exports = { createUser };
+function listUsersController(req, res) {
+  const users = listUsers();
+  res.status(200).json(users);
+}
+
+module.exports = { createUser: createUserController, listUsers: listUsersController };

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const { createUser } = require('../controllers/usersController');
+const { createUser, listUsers } = require('../controllers/usersController');
 
 router.post('/', createUser);
+router.get('/', listUsers);
 
 module.exports = router;

--- a/backend/src/services/usersService.js
+++ b/backend/src/services/usersService.js
@@ -1,0 +1,14 @@
+const users = [];
+
+function createUser(userData) {
+  const { name, email, phone, password } = userData;
+  const user = { name, email, phone, password };
+  users.push(user);
+  return user;
+}
+
+function listUsers() {
+  return users;
+}
+
+module.exports = { createUser, listUsers };


### PR DESCRIPTION
## Summary
- extract user creation and listing logic into usersService
- delegate user endpoints to service layer
- add GET /users route for listing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm start` (Servidor rodando na porta 3000)


------
https://chatgpt.com/codex/tasks/task_e_689242b023a4832681ed2dfd42e2342e