### PR TITLE
Add JWT auth middleware

### DIFF
--- a/backend/src/authMiddleware.js
+++ b/backend/src/authMiddleware.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Authorization header missing' });
+  }
+
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ error: 'Invalid authorization format' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+module.exports = authMiddleware;

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { body, validationResult } = require('express-validator');
 const router = express.Router();
 const { createUser, getUsers } = require('../controllers/usersController');
+const authMiddleware = require('../authMiddleware');
 
 const validateUser = [
   body('name').notEmpty().withMessage('Name is required'),
@@ -20,6 +21,6 @@ const validateUser = [
 ];
 
 router.post('/', validateUser, createUser);
-router.get('/', getUsers);
+router.get('/', authMiddleware, getUsers);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add middleware that validates JWT in Authorization header
- protect `GET /users` with authentication middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node src/server.js`


------
https://chatgpt.com/codex/tasks/task_e_689256260468832691770a0eafb716f3