### PR TITLE
Use bcrypt for user authentication

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
@@ -51,6 +52,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -847,6 +862,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const usersService = require('../services/usersService');
+
+async function loginUser(req, res) {
+  const { email, password } = req.body;
+  const user = usersService.findUserByEmail(email);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const validPassword = await bcrypt.compare(password, user.password);
+  if (!validPassword) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+}
+
+module.exports = { loginUser };

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -1,4 +1,3 @@
-const jwt = require('jsonwebtoken');
 const usersService = require('../services/usersService');
 
 async function createUser(req, res) {
@@ -16,15 +15,4 @@ function getUsers(req, res) {
   res.json(users);
 }
 
-function loginUser(req, res) {
-  const { email, password } = req.body;
-  const users = usersService.getUsers();
-  const user = users.find((u) => u.email === email && u.password === password);
-  if (!user) {
-    return res.status(401).json({ error: 'Invalid credentials' });
-  }
-  const token = jwt.sign({ email }, process.env.JWT_SECRET, { expiresIn: '1h' });
-  res.json({ token });
-}
-
-module.exports = { createUser, getUsers, loginUser };
+module.exports = { createUser, getUsers };

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { loginUser } = require('../controllers/usersController');
+const { loginUser } = require('../controllers/authController');
 
 router.post('/login', loginUser);
 

--- a/backend/src/services/usersService.js
+++ b/backend/src/services/usersService.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises;
 const path = require('path');
+const bcrypt = require('bcrypt');
 
 const USERS_FILE = path.join(__dirname, '..', 'users.json');
 
@@ -28,14 +29,19 @@ async function saveUsers() {
 loadUsers();
 
 async function createUser({ name, email, phone, password }) {
-  const user = { name, email, phone, password };
+  const hashedPassword = await bcrypt.hash(password, 10);
+  const user = { name, email, phone, password: hashedPassword };
   users.push(user);
   await saveUsers();
-  return user;
+  const { password: _, ...userWithoutPassword } = user;
+  return userWithoutPassword;
 }
 
 function getUsers() {
-  return users;
+  return users.map(({ password, ...user }) => user);
 }
 
-module.exports = { createUser, getUsers };
+function findUserByEmail(email) {
+  return users.find((u) => u.email === email);
+}
+module.exports = { createUser, getUsers, findUserByEmail };


### PR DESCRIPTION
## Summary
- hash user passwords on creation and omit them from service responses
- add dedicated auth controller that verifies passwords with bcrypt and issues JWTs
- update login routing and add bcrypt dependency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689261d317d883269a809f16e66badc4