### PR TITLE
Reload users file after saving to keep memory in sync

### DIFF
--- a/backend/src/services/usersService.js
+++ b/backend/src/services/usersService.js
@@ -20,6 +20,7 @@ async function loadUsers() {
 async function saveUsers() {
   try {
     await fs.writeFile(USERS_FILE, JSON.stringify(users, null, 2));
+    await loadUsers();
   } catch (error) {
     console.error('Failed to save users:', error);
     throw error;


### PR DESCRIPTION
## Summary
- Reload `users.json` after writing so in-memory list stays consistent across parallel runs

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689264f25b248326a80600cd48085d3b