### PR TITLE
feat: require JWT_SECRET at startup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,3 @@
 PORT=3000
+JWT_SECRET=changeme
+

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,6 +2,11 @@ const express = require('express');
 const app = express();
 require('dotenv').config();
 
+if (!process.env.JWT_SECRET) {
+  console.error('JWT_SECRET is not defined.');
+  process.exit(1);
+}
+
 app.use(express.json());
 
 const usersRouter = require('./routes/usersRoutes');


### PR DESCRIPTION
## Summary
- exit server startup when JWT_SECRET is missing
- add .env.example listing PORT and JWT_SECRET

## Testing
- `npm test` (fails: Missing script "test")
- `node src/server.js` (exits with "JWT_SECRET is not defined")

------
https://chatgpt.com/codex/tasks/task_e_689265f6baa8832695db0cddf808624e