### PR TITLE
Add user deletion endpoint with auth

### DIFF
--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -34,4 +34,18 @@ async function updateUser(req, res) {
   }
 }
 
-module.exports = { createUser, getUsers, updateUser };
+async function deleteUser(req, res) {
+  const { email } = req.params;
+
+  try {
+    const deleted = await usersService.deleteUser(email);
+    if (!deleted) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.status(200).json({ message: 'User deleted successfully' });
+  } catch (error) {
+    res.status(500).json({ error: 'Could not delete user' });
+  }
+}
+
+module.exports = { createUser, getUsers, updateUser, deleteUser };

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const router = express.Router();
-const { createUser, getUsers, updateUser } = require('../controllers/usersController');
+const { createUser, getUsers, updateUser, deleteUser } = require('../controllers/usersController');
 const authMiddleware = require('../middleware/authMiddleware');
 
 const validateUser = [
@@ -39,5 +39,6 @@ const validateUpdateUser = [
 router.post('/', validateUser, createUser);
 router.get('/', authMiddleware, getUsers);
 router.put('/:email', authMiddleware, validateUpdateUser, updateUser);
+router.delete('/:email', authMiddleware, deleteUser);
 
 module.exports = router;

--- a/backend/src/services/usersService.js
+++ b/backend/src/services/usersService.js
@@ -75,4 +75,14 @@ async function updateUser(email, { name, phone, password }) {
   return userWithoutPassword;
 }
 
-module.exports = { createUser, getUsers, findUserByEmail, updateUser };
+async function deleteUser(email) {
+  const index = users.findIndex((u) => u.email === email);
+  if (index === -1) {
+    return false;
+  }
+  users.splice(index, 1);
+  await saveUsers();
+  return true;
+}
+
+module.exports = { createUser, getUsers, findUserByEmail, updateUser, deleteUser };


### PR DESCRIPTION
## Summary
- add service/controller logic to delete users by email
- expose DELETE /users/:email route with JWT auth

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68926d23bffc8326adda934a6b4b0f02