### PR TITLE
feat(frontend): configurable API base URL

### DIFF
--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -7,7 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const tipoSelect = document.getElementById('tipoUsuario');
   const infoDiv = document.getElementById('infoTipo');
 
-  const API_BASE_URL = window.location.origin;
+  const API_BASE_URL =
+    document.querySelector('meta[data-base-url]')?.getAttribute('data-base-url') ||
+    window.location.origin;
 
   // Atualiza a mensagem do tipo de usuário
   if (tipoSelect && infoDiv) {

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta data-base-url="">
     <title>Cadastro - Sistema de Serviços</title>
     <style>
         body {

--- a/frontend/calendario.html
+++ b/frontend/calendario.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calendário - Sistema de Agendamentos</title>
+    <meta data-base-url="">
     <link rel="stylesheet" href="./styles.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta data-base-url="">
     <title>Genda Login- Sistema de Serviços</title>
     <style>
         body{

--- a/frontend/principal.html
+++ b/frontend/principal.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sistema de Agendamentos</title>
+    <meta data-base-url="">
     <link rel="stylesheet" href="./styles.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- allow API base URL configuration via `data-base-url` meta tag or `window.location.origin`
- update HTML pages to include configurable base URL placeholder

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68929e4e2ea88326a9f15dea94f3ada2