### PR TITLE
refactor: load users before starting server

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const app = require('./src/config/app');
+const { loadUsers } = require('./src/services/usersService');
 
 const frontendPath = path.resolve(__dirname, '../frontend');
 app.use(express.static(frontendPath));
@@ -15,7 +16,12 @@ if (!process.env.JWT_SECRET) {
   process.exit(1);
 }
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Servidor rodando na porta ${PORT}`);
-});
+async function startServer() {
+  await loadUsers();
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Servidor rodando na porta ${PORT}`);
+  });
+}
+
+startServer();

--- a/backend/src/services/usersService.js
+++ b/backend/src/services/usersService.js
@@ -26,8 +26,6 @@ async function saveUsers() {
   }
 }
 
-loadUsers();
-
 async function createUser({ name, email, phone, password }) {
   const existingUser = findUserByEmail(email);
   if (existingUser) {
@@ -84,4 +82,4 @@ async function deleteUser(email) {
   return true;
 }
 
-module.exports = { createUser, getUsers, findUserByEmail, updateUser, deleteUser };
+module.exports = { createUser, getUsers, findUserByEmail, updateUser, deleteUser, loadUsers };


### PR DESCRIPTION
## Summary
- export `loadUsers` from user service and load users before server startup
- wrap server initialization in async `startServer` and await user loading

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68929fa383ac83269326f1369663d4fe