### PR TITLE
feat: use Prisma for user persistence

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,7 +4,7 @@ const usersService = require('../services/usersService');
 
 async function loginUser(req, res) {
   const { email, password } = req.body;
-  const user = usersService.findUserByEmail(email);
+  const user = await usersService.findUserByEmail(email);
   if (!user) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -14,9 +14,13 @@ async function createUser(req, res) {
   }
 }
 
-function getUsers(req, res) {
-  const users = usersService.getUsers();
-  res.json(users);
+async function getUsers(req, res) {
+  try {
+    const users = await usersService.getUsers();
+    res.json(users);
+  } catch (error) {
+    res.status(500).json({ error: 'Could not retrieve users' });
+  }
 }
 
 async function updateUser(req, res) {


### PR DESCRIPTION
## Summary
- refactor user service to store data through Prisma instead of filesystem
- adapt controllers for async Prisma queries

## Testing
- `DATABASE_URL="file:./prisma/dev.db" npx prisma migrate deploy`
- `DATABASE_URL="file:./prisma/dev.db" npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_6892ab1108048326aa82339cee0ef07a