### PR TITLE
test: isolate database and verify auth middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "keywords": [],
   "author": "",

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -1,4 +1,4 @@
-process.env.JWT_SECRET = 'testsecret';
+require('./setup');
 
 const request = require('supertest');
 const app = require('../src/config/app');

--- a/backend/tests/appointments.test.js
+++ b/backend/tests/appointments.test.js
@@ -18,7 +18,7 @@ jest.mock('fs', () => ({
   },
 }));
 
-process.env.JWT_SECRET = 'testsecret';
+require('./setup');
 
 const request = require('supertest');
 const app = require('../src/config/app');

--- a/backend/tests/authMiddleware.test.js
+++ b/backend/tests/authMiddleware.test.js
@@ -1,0 +1,18 @@
+require('./setup');
+
+const jwt = require('jsonwebtoken');
+const authMiddleware = require('../src/middleware/authMiddleware');
+
+describe('authMiddleware', () => {
+  it('should attach user data from token to req.user', () => {
+    const token = jwt.sign({ id: 1, email: 'test@example.com' }, process.env.JWT_SECRET);
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toMatchObject({ id: 1, email: 'test@example.com' });
+  });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,0 +1,33 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.DATABASE_URL = 'file:memdb1?mode=memory&cache=shared';
+
+const { PrismaClient } = require('@prisma/client');
+const fs = require('fs');
+const path = require('path');
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  await prisma.$executeRaw`
+    CREATE TABLE IF NOT EXISTS "User" (
+      "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      "name" TEXT NOT NULL,
+      "email" TEXT NOT NULL UNIQUE,
+      "phone" TEXT NOT NULL,
+      "password" TEXT NOT NULL
+    );
+  `;
+});
+
+afterEach(async () => {
+  await prisma.user.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+  const dbPath = path.join(__dirname, '..', 'prisma', 'memdb1');
+  if (fs.existsSync(dbPath)) {
+    fs.unlinkSync(dbPath);
+  }
+});
+
+module.exports = prisma;


### PR DESCRIPTION
## Summary
- use an in-memory SQLite database for backend tests and reset between runs
- add unit test ensuring auth middleware populates req.user from JWT
- run Jest sequentially to maintain isolated database state

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b1e7260883269debc8aac4cba510