### PR TITLE
docs: add env setup and migration instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,6 +4,20 @@ API de agendamentos com intermediação de pagamentos e proteção a prestadores
 
 ## Como rodar
 
-```bash
-npm install
-npm run dev
+1. Crie um arquivo `.env` na pasta `backend` com as variáveis:
+   ```
+   JWT_SECRET=<sua_chave_secreta>
+   DATABASE_URL=<url_do_banco>
+   ```
+2. Instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Execute as migrations:
+   ```bash
+   npx prisma migrate dev
+   ```
+4. Inicie o servidor de desenvolvimento:
+   ```bash
+   npm run dev
+   ```


### PR DESCRIPTION
## Summary
- document required `.env` with `JWT_SECRET` and `DATABASE_URL`
- guide running `npx prisma migrate dev` before starting development server

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f21c4c1c83268c7d1dfc2f8a6aee